### PR TITLE
Implement Feed and Edit Me pages with post interaction features

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,7 +1,14 @@
 <script setup>
 import { RouterLink, RouterView } from 'vue-router';
+import { onMounted } from 'vue';
+import { useUserStore } from '@/stores/user';
 import Header from './components/Header.vue';
 import FooterTab from './components/FooterTab.vue';
+
+const userStore = useUserStore();
+onMounted(() => {
+  userStore.checkUserFromToken();
+});
 </script>
 
 <template>

--- a/client/src/components/PopupForm.vue
+++ b/client/src/components/PopupForm.vue
@@ -1,0 +1,63 @@
+<script setup>
+import { ref } from 'vue';
+
+const emit = defineEmits(['submit', 'close']);
+const props = defineProps({
+  isVisible: Boolean,
+  title: String,
+  placeholder: String,
+  inputText: String
+});
+
+// ローカルステートとしてinputTextをコピー
+const localInputText = ref(props.inputText);
+
+const submit = () => {
+  if (localInputText.value.trim() !== '') {
+    emit('submit', localInputText.value); // 送信イベントを親に通知
+    localInputText.value = '';
+  }
+};
+
+const closePopup = () => {
+  emit('close'); // 親コンポーネントに閉じる通知を送る
+};
+</script>
+
+<template>
+  <div v-if="isVisible">
+    <div
+      tabindex="-1"
+      :class="{ hidden: !isVisible }"
+      class="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 w-1/3 md:inset-0 h-modal md:h-full"
+    >
+      <div class="p-4 w-full max-w-lg h-full md:h-auto">
+        <div class="relative p-4 bg-white rounded-lg shadow dark:bg-gray-800 md:p-8">
+          <button
+            class="absolute -top-[0.6rem] -right-[0.8rem] w-7 h-7 rounded-full bg-[#313539] text-[#f4f2f0] text-lg font-thin leading-7 text-center border-none cursor-pointer"
+            @click="closePopup"
+          >
+            &#10005;
+          </button>
+          <div class="mb-4 text-sm font-light text-gray-500 dark:text-gray-400">
+            <h3 class="mb-3 text-2xl text-center font-bold text-gray-900 dark:text-white">{{ title }}</h3>
+            <textarea
+              v-model="localInputText"
+              :placeholder="placeholder"
+              maxlength="800"
+              class="flex justify-between w-full h-28 py-5 px-4 mb-8 text-sm text-dark border border-dark bg-white/35 rounded-3xl"
+            ></textarea>
+          </div>
+          <div class="flex self-end">
+            <button
+              @click="submit"
+              class="ml-auto bg-orange text-ivory font-en w-16 h-10 rounded-xl hover:bg-orange-700"
+            >
+              Post
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -5,15 +5,9 @@ import { createPinia } from 'pinia';
 
 import App from './App.vue';
 import router from './router';
-import { useUserStore } from './stores/user';
 
 const app = createApp(App);
-const pinia = createPinia();
-app.use(pinia);
+app.use(createPinia());
 app.use(router);
 
-app.mount('#app').then(() => {
-  // アプリケーションがマウントされた後にユーザーストアのチェックアクションを呼び出す
-  const userStore = useUserStore();
-  userStore.checkUserFromToken();
-});
+app.mount('#app');

--- a/client/src/stores/posts.js
+++ b/client/src/stores/posts.js
@@ -1,0 +1,43 @@
+import { defineStore } from 'pinia';
+import axiosInstance from '@/axios';
+
+export const usePostsStore = defineStore({
+  id: 'posts',
+  state: () => ({
+    posts: [],
+    myPosts: [],
+    isLoading: false,
+    error: null
+  }),
+  getters: {
+    allPosts: state => state.posts,
+    revisionRequestedPosts: state => state.posts.filter(post => post.revisionRequested === true)
+  },
+  actions: {
+    async fetchPostsWithDetail() {
+      this.isLoading = true;
+      this.error = null;
+      try {
+        const res = await axiosInstance.get('/posts-with-details');
+        this.posts = res.data.posts;
+      } catch (error) {
+        console.error('Failed to fetch posts with users:', error);
+        this.error = 'Failed to load posts.';
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    async fetchMyPosts() {
+      this.isLoading = true;
+      this.error = null;
+      try {
+        const res = await axiosInstance.get('/my-posts');
+        this.myPosts = res.data.posts;
+      } catch (error) {
+        console.error('Failed to fetch my diary:', error);
+      } finally {
+        this.isLoading = false;
+      }
+    }
+  }
+});

--- a/client/src/stores/user.js
+++ b/client/src/stores/user.js
@@ -18,7 +18,7 @@ export const useUserStore = defineStore({
       const token = localStorage.getItem('jwt');
       if (token) {
         try {
-          const res = await axiosInstance.get('/api/user/info', {
+          const res = await axiosInstance.get('/user/info', {
             headers: {
               Authorization: `Bearer ${token}`
             }

--- a/client/src/views/EditmeView.vue
+++ b/client/src/views/EditmeView.vue
@@ -1,9 +1,371 @@
-<script setup></script>
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+import { usePostsStore } from '@/stores/posts';
+import axiosInstance from '@/axios';
+import PopupForm from '@/components/PopupForm.vue';
+import UserIcon from '@/assets/icons/icon_user.png';
+
+const postsStore = usePostsStore();
+const posts = computed(() => postsStore.allPosts);
+const displayComments = ref(false);
+const displayCorrections = ref(false);
+const comments = ref([]);
+const corrections = ref([]);
+const isPopupVisible = ref(false);
+const currentMode = ref(null); // 'comment' または 'correction'
+const currentInputText = ref('');
+const selectedPostId = ref(null);
+
+onMounted(async () => {
+  await postsStore.fetchPostsWithDetail();
+});
+
+const formatDate = dateStr => {
+  const date = new Date(dateStr);
+
+  // 各部分のゼロ埋め
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  // カスタムフォーマットの組み立て
+  return `${year}/${month}/${day} ${hours}:${minutes}`;
+};
+
+const timeSince = date => {
+  const seconds = Math.floor((new Date() - date) / 1000);
+  let interval = seconds / 31536000;
+
+  if (interval > 1) {
+    return date.toLocaleDateString();
+  }
+  interval = seconds / 2592000;
+  if (interval > 1) {
+    return Math.floor(interval) + ' months ago';
+  }
+  interval = seconds / 86400;
+  if (interval > 1) {
+    return Math.floor(interval) + 'd';
+  }
+  interval = seconds / 3600;
+  if (interval > 1) {
+    return Math.floor(interval) + 'h';
+  }
+  interval = seconds / 60;
+  if (interval > 1) {
+    return Math.floor(interval) + 'm';
+  }
+  return Math.floor(seconds) + ' seconds ago';
+};
+
+const fetchCommentsForPost = async postId => {
+  try {
+    const res = await axiosInstance.get(`/comments/${postId}`);
+    console.log('コメント:', res.data.comments);
+    comments.value = res.data.comments;
+  } catch (error) {
+    console.error(`Failed to fetch comments ${postId}:`, error);
+    comments.value = [];
+  }
+};
+
+const fetchCorrectionsForPost = async postId => {
+  try {
+    console.log('添削をフェッチするよ');
+    const res = await axiosInstance.get(`/corrections/${postId}`);
+    console.log('添削:', res.data.corrections);
+    corrections.value = res.data.corrections;
+  } catch (error) {
+    console.error(`Failed to fetch corrections ${postId}:`, error);
+    corrections.value = [];
+  }
+};
+
+// Updateしたポストだけを更新
+const updateSpecificPostDetails = async postId => {
+  try {
+    const res = await axiosInstance.get(`/post-details/${postId}`);
+    const updatedPostDetails = res.data;
+
+    const index = postsStore.allPosts.findIndex(post => post.postId === postId);
+    if (index !== -1) {
+      postsStore.allPosts[index] = updatedPostDetails;
+    }
+  } catch (error) {
+    console.error(`Failed to update post details for ${postId}:`, error);
+  }
+};
+
+const togglePopup = async (postId, mode, count) => {
+  console.log(`postId:`, postId);
+  console.log(`selectedPostId:`, selectedPostId.value);
+  if (selectedPostId.value === postId && currentMode.value === mode) {
+    console.log('Closing popup for the same post and mode.');
+    if (mode === 'comment') {
+      isPopupVisible.value = !displayComments.value;
+      displayComments.value = !displayComments.value;
+    } else {
+      isPopupVisible.value = !displayCorrections.value;
+      displayCorrections.value = !displayCorrections.value;
+    }
+  } else {
+    console.log('Opening popup for a new post or mode.');
+    currentMode.value = mode;
+    selectedPostId.value = postId;
+    isPopupVisible.value = true;
+    if (mode === 'comment') {
+      displayComments.value = true;
+      displayCorrections.value = false;
+      if (count > 0) {
+        await fetchCommentsForPost(postId);
+      }
+    } else {
+      displayCorrections.value = true;
+      displayComments.value = false;
+      if (count > 0) {
+        await fetchCorrectionsForPost(postId);
+      }
+    }
+  }
+};
+
+const sendComment = async (postId, content) => {
+  try {
+    await axiosInstance.post('/comments', { postId, content });
+    await updateSpecificPostDetails(postId);
+  } catch (error) {
+    console.error('Error sending comment:', error);
+  }
+};
+
+const sendCorrection = async (postId, content) => {
+  try {
+    await axiosInstance.post('/corrections', { postId, content });
+    await updateSpecificPostDetails(postId);
+  } catch (error) {
+    console.error('Error sending correction:', error);
+  }
+};
+
+const handleSubmit = async text => {
+  if (currentMode.value === 'comment') {
+    await sendComment(selectedPostId.value, text);
+    // コメントリストを更新
+    fetchCommentsForPost(selectedPostId.value);
+    displayComments.value = true; // コメント表示を維持
+  } else {
+    await sendCorrection(selectedPostId.value, text);
+    // 添削リストを更新
+    fetchCorrectionsForPost(selectedPostId.value);
+    displayCorrections.value = true; // 添削表示を維持
+  }
+  isPopupVisible.value = false; // ポップアップを閉じる
+};
+
+const closePopup = () => {
+  isPopupVisible.value = false;
+};
+</script>
 
 <template>
   <div class="pt-24 px-5">
     <h2 class="font-jp text-dark text-base font-thin text-center mb-1">添削リクエスト一覧</h2>
     <p class="font-jp text-dark text-xs text-center mb-12">添削してあげることで勉強になるよ</p>
-    <!-- <div v-for="post in posts" :key="post.id" class="w-full mb-4"> -->
+
+    <!-- 日記の表示 -->
+    <div v-for="post in posts" :key="post.id" class="w-full mb-4">
+      <div class="flex items-center">
+        <div class="flex justify-start items-center space-x-1.5 mb-2 pl-1">
+          <img
+            :src="post.profileImageUrl || '@/assets/icons/icon_user.png'"
+            alt="User Icon"
+            class="w-11 h-11 rounded-full object-cover"
+          />
+          <span class="text-dark font-bold">{{ post.username }}</span>
+        </div>
+        <span class="text-dark text-sm font-en ml-auto pr-2">{{ formatDate(post.createdAt) }}</span>
+      </div>
+
+      <div class="w-full">
+        <div class="flex gap-0">
+          <!-- 日本語部分 -->
+          <div class="relative w-full">
+            <div class="absolute top-3 left-3 flex justify-center items-center w-9 h-9 bg-ivory rounded-full">
+              <span class="text-sm font-fr">JP</span>
+            </div>
+            <div
+              class="read-more border-r border-ivory50 flex-1 container mx-auto p-3 pt-14 rounded-l-3xl h-72 leading-6 font-jp bg-dark text-ivory text-sm"
+            >
+              <div id="scrollbar">
+                {{ post.jpText }}
+              </div>
+            </div>
+          </div>
+          <!-- フランス語部分 -->
+          <div class="relative w-full">
+            <div class="absolute top-3 left-3 flex justify-center items-center w-9 h-9 bg-ivory rounded-full">
+              <span class="text-sm font-fr">FR</span>
+            </div>
+            <div
+              class="border-r border-ivory50 flex-1 container mx-auto p-3 pt-14 rounded-r-3xl h-72 leading-6 font-jp bg-dark text-ivory text-sm"
+            >
+              <div id="scrollbar">
+                {{ post.frText }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- 添削リクエスト -->
+      <div class="flex justify-end items-center mt-3 mr-0.5">
+        <div
+          :class="{
+            'revision-request-true': post.revisionRequested,
+            'revision-request-false': !post.revisionRequested
+          }"
+        ></div>
+        <!-- <div class="revision-request-true"></div> -->
+        <span class="ml-[0.5em] text-sm font-jp text-dark">添削リクエスト</span>
+      </div>
+
+      <!-- 通知バッジ群 -->
+      <div class="flex justify-end mt-1 mr-4 mb-2">
+        <button
+          type="button"
+          class="relative inline-flex items-center p-3"
+          @click="togglePopup(post.postId, 'comment', post.commentCount)"
+        >
+          <img src="@/assets/icons/icon_comment.svg" alt="My dico" class="w-5 h-5" aria-hidden="true" />
+          <div
+            v-if="post.commentCount > 0"
+            class="absolute inline-flex items-center justify-center w-5 h-5 text-[0.6rem] text-dark bg-orange rounded-full top-0 -end-[0.6rem]"
+          >
+            {{ post.commentCount }}
+          </div>
+        </button>
+        <button
+          type="button"
+          class="relative inline-flex items-center p-3"
+          @click="togglePopup(post.postId, 'correction', post.correctionCount)"
+        >
+          <img src="@/assets/icons/icon_edited.svg" alt="My dico" class="w-5 h-5" aria-hidden="true" />
+          <div
+            v-if="post.correctionCount > 0"
+            class="absolute inline-flex items-center justify-center w-5 h-5 text-[0.6rem] text-dark bg-orange rounded-full top-0 -end-[0.6rem]"
+          >
+            {{ post.correctionCount }}
+          </div>
+        </button>
+      </div>
+
+      <!-- コメントセクション -->
+      <div v-if="displayComments && selectedPostId === post.postId" class="flex flex-col items-center">
+        <p class="font-jp text-dark text-sm font-semibold text-center mb-4">コメント</p>
+        <!-- コメントリスト表示 -->
+        <div
+          v-for="comment in comments"
+          :key="comment.commentId"
+          class="flex justify-between w-1/2 py-6 px-4 mb-8 bg-white/50 rounded-3xl"
+        >
+          <div class="flex items-center space-x-4">
+            <!-- ユーザーアイコン -->
+            <img
+              :src="comment.profileImageUrl || UserIcon"
+              class="w-11 h-11 rounded-full object-cover"
+              :alt="comment.username"
+            />
+            <!-- コメント内容 -->
+            <div class="flex flex-col space-y-1">
+              <span class="font-bold text-dark">{{ comment.username }}</span>
+              <span class="text-sm text-dark">{{ comment.content }}</span>
+            </div>
+          </div>
+          <div class="flex-none px-4 py-2 text-stone-600 text-xs md:text-sm">
+            {{ timeSince(new Date(comment.createdAt)) }}
+          </div>
+        </div>
+      </div>
+
+      <!-- 添削セクション -->
+      <div v-if="displayCorrections && selectedPostId === post.postId" class="flex flex-col items-center">
+        <p class="font-jp text-dark text-sm font-semibold text-center mb-4">添削</p>
+        <!-- 添削リスト表示 -->
+        <div
+          v-for="correction in corrections"
+          :key="correction.correctionId"
+          class="flex justify-between w-1/2 py-6 px-4 mb-8 bg-white/50 rounded-3xl"
+        >
+          <div class="flex items-center space-x-4">
+            <!-- ユーザーアイコン -->
+            <img
+              :src="correction.profileImageUrl || UserIcon"
+              class="w-11 h-11 rounded-full object-cover"
+              :alt="correction.username"
+            />
+            <!-- 添削内容 -->
+            <div class="flex flex-col space-y-1">
+              <span class="font-bold text-dark">{{ correction.username }}</span>
+              <span class="text-sm text-dark">{{ correction.content }}</span>
+            </div>
+          </div>
+          <div class="flex-none px-4 py-2 text-stone-600 text-xs md:text-sm">
+            {{ timeSince(new Date(correction.createdAt)) }}
+          </div>
+        </div>
+      </div>
+
+      <!-- ポップアップ -->
+      <div v-if="isPopupVisible && selectedPostId === post.postId">
+        <PopupForm
+          :isVisible="isPopupVisible"
+          :title="currentMode === 'comment' ? 'Add Comment' : 'Add Correction'"
+          :placeholder="currentMode === 'comment' ? 'コメントを入力してください' : '添削を入力してください'"
+          :inputText="currentInputText"
+          @close="closePopup"
+          @submit="handleSubmit"
+        />
+      </div>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.revision-request-true {
+  width: 17px;
+  height: 17px;
+  background-color: var(--custom-orange);
+  border: none;
+  border-radius: 3px;
+  position: relative; /* ポジショニングの基点となる */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px; /* チェックマークのサイズを調整 */
+}
+
+.revision-request-true::after {
+  content: '✓'; /* チェックマーク */
+  color: white; /* チェックマークの色 */
+  font-weight: bold;
+}
+
+.revision-request-false {
+  width: 17px;
+  height: 17px;
+  background-color: transparent;
+  border: solid var(--custom-dark);
+  border-radius: 3px;
+}
+
+/* .read-more {
+  position: relative;
+} */
+
+/* スクロールバーの設定を適用 */
+.read-more > div {
+  max-height: 220px;
+  overflow: auto; /* スクロールバーを表示 */
+}
+</style>

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -1,0 +1,69 @@
+const { db, admin } = require('../firebaseAdmin');
+
+class Comment {
+  constructor({ commentId, postId, uid, username, content, createdAt, updatedAt, profileImageUrl }) {
+    this.commentId = commentId;
+    this.postId = postId;
+    this.uid = uid;
+    this.username = username || '';
+    this.profileImageUrl = profileImageUrl || '';
+    this.content = content;
+    this.createdAt = createdAt || new Date();
+    this.updatedAt = updatedAt || new Date();
+  }
+
+  // コメントデータを新規追加または更新
+  async save() {
+    const commentData = this.toJson();
+    if (this.commentId) { // コメントIDが存在する場合は更新
+      await db.collection('comments').doc(this.commentId).update(commentData);
+    } else { // 新規作成
+      const docRef = await db.collection('comments').add(commentData);
+      this.commentId = docRef.id;  // 新規作成した場合、IDをクラスにセット
+    }
+  }
+
+  // コメントをFirestoreから削除
+  async deleteComment() {
+    try {
+      await db.collection('comments').doc(this.commentId).delete();
+    } catch (error) {
+      console.error('コメントの削除中にエラーが発生しました:', error);
+    }
+  }
+
+  // FirestoreのDocumentSnapshotからCommentインスタンスを生成
+  static fromFirestore(doc) {
+    const data = doc.data();
+    return new Comment({
+      commentId: doc.id,
+      postId: data.postId,
+      uid: data.uid,
+      username: data.username,
+      profileImageUrl: data.profileImageUrl,
+      content: data.content,
+      createdAt: data.createdAt.toDate(),
+      updatedAt: data.updatedAt.toDate(),
+    });
+  }
+
+  // Firestore用にデータをシリアライズ
+  toJson() {
+    let serializedData = {
+      postId: this.postId,
+      uid: this.uid,
+      username: this.username,
+      profileImageUrl: this.profileImageUrl,
+      content: this.content,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+    // commentId が存在する場合のみ serializedData に追加
+    if (this.commentId) {
+      serializedData.commentId = this.commentId;
+    }
+    return serializedData;
+  }
+}
+
+module.exports = Comment;

--- a/server/models/correction.js
+++ b/server/models/correction.js
@@ -1,0 +1,57 @@
+const { db, admin } = require('../firebaseAdmin');
+
+class Correction {
+  constructor({ correctionId, postId, uid, username, content, createdAt, updatedAt, profileImageUrl }) {
+    this.correctionId = correctionId;
+    this.postId = postId;
+    this.uid = uid;
+    this.username = username || '';
+    this.content = content;
+    this.createdAt = createdAt || new Date();
+    this.updatedAt = updatedAt || new Date();
+    this.profileImageUrl = profileImageUrl || '';
+  }
+
+  async save() {
+    const correctionData = this.toJson();
+    if (this.correctionId) {
+      await db.collection('corrections').doc(this.correctionId).update(correctionData);
+    } else {
+      const docRef = await db.collection('corrections').add(correctionData);
+      this.correctionId = docRef.id; // 新規作成した場合、IDをクラスにセット
+    }
+  }
+
+  // FirestoreのDocumentSnapshotからCorrectionインスタンスを生成
+  static fromFirestore(doc) {
+    const data = doc.data();
+    return new Correction({
+      correctionId: doc.id,
+      postId: data.postId,
+      uid: data.uid,
+      username: data.username,
+      content: data.content, // 添削内容のみを保持
+      createdAt: data.createdAt.toDate(),
+      updatedAt: data.updatedAt.toDate(),
+      profileImageUrl: data.profileImageUrl,
+    });
+  }
+
+  toJson() {
+    let serializedData = {
+      postId: this.postId,
+      uid: this.uid,
+      username: this.username,
+      content: this.content,
+      createdAt: this.createdAt instanceof admin.firestore.Timestamp ? this.createdAt.toDate().toISOString() : this.createdAt,
+      updatedAt: this.updatedAt instanceof admin.firestore.Timestamp ? this.updatedAt.toDate().toISOString() : this.updatedAt,
+      profileImageUrl: this.profileImageUrl,
+    };
+    if (this.correctionId) {
+      serializedData.correctionId = this.correctionId;
+    }
+    return serializedData;
+  }
+}
+
+module.exports = Correction;

--- a/server/models/post.js
+++ b/server/models/post.js
@@ -54,7 +54,7 @@ class Post {
       jpText: this.jpText,
       frText: this.frText,
       aiText: this.aiText,
-      createdAt: this.createdAt instanceof admin.firestore.Timestamp ? this.createdAt : admin.firestore.Timestamp.fromDate(this.createdAt),
+      createdAt: this.createdAt instanceof admin.firestore.Timestamp ? this.createdAt.toDate().toISOString() : this.createdAt,
       privacyLevel: this.privacyLevel,
       revisionRequested: this.revisionRequested,
       comments: this.comments,

--- a/server/verifyJwtToken.js
+++ b/server/verifyJwtToken.js
@@ -5,6 +5,7 @@ const secretKey = process.env.JWT_SECRET;
 // JWTの検証
 const verifyJwtToken = (req, res, next) => {
   const authHeader = req.headers['authorization'];
+  console.log(authHeader);
   const token = authHeader && authHeader.split(' ')[1]; // Bearerトークンの形式に対応
 
   if (!token) {
@@ -16,6 +17,7 @@ const verifyJwtToken = (req, res, next) => {
     if (err) {
       return res.status(401).send({ message: 'Failed to authenticate token.' });
     }
+    console.log('Authenticated user:', user);  // ユーザー情報をログ出力
     // ユーザー情報をreq.userに保存
     req.user = user;
     next();


### PR DESCRIPTION
This pull request includes the implementation of the Feed and Edit Me pages with user interactions such as commenting and corrections.

Here are the key changes:
**Feed Page**
-  Users can view all public diary posts.
-  Add function to comment and request corrections per the poster's preferences.
-  Displays notification badges showing the count of comments and corrections on each post icon.

**Edit Me Page**
- Almost same as Feed page but filters to show only posts where `revisionRequested: true`.
- Create this page to actively encourage community participation
