### PR TITLE
Add Dico page for user dictionary entries

### DIFF
--- a/client/src/components/FooterTab.vue
+++ b/client/src/components/FooterTab.vue
@@ -25,7 +25,7 @@ const showTooltip = ref(false);
 
 <template>
   <footer
-    class="font-en w-[600px] rounded-3xl fixed bottom-2.5 left-1/2 -translate-x-1/2 z-30 bg-dark shadow-md flex justify-around items-center"
+    class="font-en w-[600px] rounded-3xl fixed bottom-5 left-1/2 -translate-x-1/2 z-30 bg-dark shadow-md flex justify-around items-center"
   >
     <nav class="flex justify-between items-center max-w-screen-xl mx-auto px-[2.75rem] py-[0.6rem]">
       <router-link to="/" class="tab" :class="{ active: $route.path === '/' }">

--- a/client/src/components/Snackbar.vue
+++ b/client/src/components/Snackbar.vue
@@ -1,25 +1,24 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 
 const props = defineProps({
   message: String,
-  duration: {
-    type: Number,
-    default: 3000
-  }
+  isVisible: Boolean
 });
 
-const visible = ref(false);
+const visible = ref(props.isVisible);
 
-// const show = () => {
-//   visible.value = true;
-//   setTimeout(() => {
-//     visible.value = false;
-//   }, props.duration);
-// };
-
-// // setup() から show メソッドを直接返して、コンポーネント外からアクセス可能にする
-// export { show };
+watch(
+  () => props.isVisible,
+  newVal => {
+    visible.value = newVal;
+    if (newVal) {
+      setTimeout(() => {
+        visible.value = false; // 一定時間後に自動で閉じる
+      }, 3000);
+    }
+  }
+);
 </script>
 
 <template>
@@ -29,3 +28,20 @@ const visible = ref(false);
     </div>
   </transition>
 </template>
+
+<style scoped>
+.snackbar {
+  width: 100%;
+  position: fixed;
+  bottom: 100px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--custom-orange);
+  color: var(--custom-ivory);
+  font-weight: 600;
+  text-align: center;
+  padding: 10px 20px;
+  border-radius: 5px;
+  animation: slide-in-out 3s;
+}
+</style>

--- a/client/src/views/DiaryView.vue
+++ b/client/src/views/DiaryView.vue
@@ -672,7 +672,7 @@ const showPreviousDiary = () => {
           </div>
         </div>
         <!-- 前の日記、次の日記 -->
-        <div class="flex justify-center items-center mt-0 w-full px-12">
+        <div class="flex justify-center items-center my-4 w-full px-12">
           <a href="#" v-if="currentIndex > 0" class="text-sm font-jp text-dark expansion" @click="showNextDiary">
             &lt; &nbsp;&nbsp;前の日記
           </a>

--- a/client/src/views/DicoView.vue
+++ b/client/src/views/DicoView.vue
@@ -1,21 +1,30 @@
 <script setup>
 import { ref } from 'vue';
 import axiosInstance from '@/axios';
+import Snackbar from '@/components/Snackbar.vue';
 
 const jpWord = ref('');
 const frWord = ref('');
+const snackbarVisible = ref(false);
+const snackbarMessage = ref('');
 
-// Addボタンのクリックアクション
 const addDico = async () => {
   try {
-    const res = await axiosInstance.post('/post', {
-      jpWord: jpWord.value,
-      frText: frWord.value
+    const res = await axiosInstance.post('/dico', {
+      term: frWord.value,
+      definition: jpWord.value
     });
-    console.log('Diary data posted:', res.data);
-    frWord.value = res.data.frWord;
+    console.log('Dico data added:', res.data);
+    frWord.value = '';
+    jpWord.value = '';
+    snackbarMessage.value = '辞書が登録されました';
+    snackbarVisible.value = true;
+    setTimeout(() => (snackbarVisible.value = false), 3000); // 3秒後にスナックバーを非表示にする
   } catch (error) {
-    console.error('Error posting diary data:', error);
+    console.error('Error adding Dico data:', error);
+    snackbarMessage.value = '辞書の登録に失敗しました';
+    snackbarVisible.value = true;
+    setTimeout(() => (snackbarVisible.value = false), 3000); // 3秒後にスナックバーを非表示にする
   }
 };
 </script>
@@ -44,7 +53,7 @@ const addDico = async () => {
             <span class="text-sm font-fr">JP</span>
           </div>
           <textarea
-          v-model="jpWord"
+            v-model="jpWord"
             maxlength="300"
             type="text"
             pattern="^[a-zA-Z0-9]+$"
@@ -61,6 +70,7 @@ const addDico = async () => {
         >
           Add
         </button>
+        <Snackbar :isVisible="snackbarVisible" :message="snackbarMessage" />
         <div class="flex justify-end mt-3">
           <router-link to="/my-dico">
             <div class="flex flex-col justify-center items-center w-[60px] h-[60px] bg-dark rounded-[15px]">

--- a/client/src/views/MyDicoView.vue
+++ b/client/src/views/MyDicoView.vue
@@ -5,11 +5,12 @@
     <h2 class="font-jp text-dark text-base font-thin text-center mb-1">My Dico</h2>
   </div>
 
+  <h1 class="text-6xl text-dark text-center mt-20 mb-20">Under Construction</h1>
   <div class="flex justify-center">
     <nav class="flex space-x-2" aria-label="Pagination">
       <a
         href="#"
-        class="relative inline-flex items-center px-4 py-2 text-sm   text-dark font-semibold cursor-pointer leading-5 rounded-md transition duration-150 ease-in-out focus:outline-none focus:shadow-outline-blue focus:border-blue-300 focus:z-10"
+        class="relative inline-flex items-center px-4 py-2 text-sm  text-dark font-semibold cursor-pointer leading-5 rounded-md transition duration-150 ease-in-out focus:outline-none focus:shadow-outline-blue focus:border-blue-300 focus:z-10"
       >
         Previous
       </a>

--- a/server/models/dico.js
+++ b/server/models/dico.js
@@ -1,0 +1,57 @@
+const { db, admin } = require('../firebaseAdmin');
+
+class Dico {
+  constructor({ dicoid, uid, term, definition, createdAt, alphabet }) {
+    this.dicoid = dicoid;
+    this.uid = uid;
+    this.term = term;
+    this.definition = definition;
+    this.createdAt = createdAt || new Date();
+    this.alphabet = alphabet;
+  }
+
+  // FirestoreにDicoデータを新規追加
+  async save() {
+    const docRef = await db.collection('dico').add(this.toJson());
+    const dicoid = docRef.id;
+    await docRef.update({ dicoid: dicoid });
+  }
+
+  async deleteDico() {
+      try {
+        await db.collection('dico').doc(this.dicoid).delete();
+      } catch (error) {
+        console.error('辞書データの削除中にエラーが発生しました:', error);
+      }
+  }
+
+  // FirestoreのDocumentSnapshotからDicoインスタンスを生成
+  static fromFirestore(doc) {
+    const data = doc.data();
+    return new Dico({
+      dicoid: doc.id,
+      uid: data.uid,
+      term: data.term,
+      definition: data.definition,
+      createdAt: data.createdAt.toDate(),
+      alphabet: data.alphabet,
+    });
+  }
+
+  // Firestore用にデータをシリアライズ
+  toJson() {
+    let serializedData = {
+      uid: this.uid,
+      term: this.term,
+      definition: this.definition,
+      createdAt: this.createdAt instanceof admin.firestore.Timestamp ? this.createdAt.toDate().toISOString() : this.createdAt,
+      alphabet: this.alphabet,
+    };
+    if (this.dicoid) {
+      serializedData.dicoid = this.dicoid;
+    }
+    return serializedData;
+  }
+}
+
+module.exports = Dico;

--- a/server/routes.js
+++ b/server/routes.js
@@ -9,6 +9,7 @@ const User = require('./models/user');
 const Post = require('./models/post');
 const Comment = require('./models/comment');
 const Correction = require('./models/correction');
+const Dico = require('./models/dico');
 
 const authKey = process.env.DEEPL_API_KEY;
 const translator = new deepl.Translator(authKey);
@@ -583,6 +584,38 @@ router.delete('/delete-post/:postId', verifyJwtToken, async (req, res) => {
   } catch (error) {
     console.error('Error deleting post:', error);
     res.status(500).json({ message: 'Server Error' });
+  }
+});
+
+// 辞書データを追加するPOSTエンドポイント
+router.post('/dico', verifyJwtToken, async (req, res) => {
+  console.log('辞書登録リクエスト来たー');
+
+  if (!req.user || !req.user.id) {
+    return res.status(403).send({ message: 'Access forbidden for guest users' });
+  }
+
+  const { term, definition } = req.body;
+  if (!term || !definition) {
+    return res.status(400).send({ message: 'Term and definition are required.' });
+  }
+
+  try {
+    const alphabet = term.charAt(0).toUpperCase();
+    const newDico = new Dico({
+      uid: req.user.id,
+      term,
+      definition,
+      alphabet,
+      createdAt: new Date()
+    });
+    
+    await newDico.save();
+
+    res.status(201).send({ message: 'Dico data added successfully', dicoId: newDico.dicoid });
+  } catch (error) {
+    console.error('Error adding Dico data:', error);
+    res.status(500).send({ message: 'Failed to add Dico data', error: error.message });
   }
 });
 


### PR DESCRIPTION
This pull request includes the implementation of the Dico page which allows users to add French terms to their personal dictionary.

Here are the key changes:
**Dico page:**

Users can add French terms to their dictionary.
Created the data model necessary for storing user dictionary entries.

**Others:**
Implemented a Snackbar component to display success or error messages when users add new entries.
