### PR TITLE
Add Firebase auth based on updated Firestore access rules

### DIFF
--- a/client/src/firebase.js
+++ b/client/src/firebase.js
@@ -1,6 +1,6 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from 'firebase/app';
-import { getAuth, signOut } from 'firebase/auth';
+import { getAuth, signOut, signInWithCredential, GoogleAuthProvider } from 'firebase/auth';
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -17,4 +17,19 @@ const firebase = initializeApp(firebaseConfig);
 
 const auth = getAuth(firebase);
 
-export { auth, signOut };
+const signInToFirebase = async () => {
+  const googleIdToken = localStorage.getItem('googleIdToken');
+  if (googleIdToken) {
+    try {
+      const credential = GoogleAuthProvider.credential(googleIdToken);
+      await signInWithCredential(auth, credential);
+      console.log('Firebaseサインイン成功');
+    } catch (error) {
+      console.error('Firebaseサインインエラー:', error);
+    }
+  } else {
+    console.log('Google IDトークンが見つかりません');
+  }
+};
+
+export { auth, signOut, signInToFirebase };

--- a/client/src/views/AccountView.vue
+++ b/client/src/views/AccountView.vue
@@ -4,6 +4,7 @@ import { ref, onMounted, watch } from 'vue';
 import { useUserStore } from '@/stores/user';
 import UserIcon from '@/assets/icons/icon_user.png';
 import { getStorage, ref as storageRef, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { signInToFirebase } from '@/firebase';
 
 const userStore = useUserStore();
 
@@ -13,7 +14,8 @@ let editMode = ref(false); // 編集モードを管理するためのref
 let selectedFile = ref(null); // 選択された画像ファイルを保持するための変数
 let previewImageUrl = ref(null);
 
-onMounted(() => {
+onMounted(async () => {
+  await signInToFirebase(); // Firebaseにサインインを確認
   if (userStore.user) {
     userInfo.value = { ...userStore.user };
     initialUserInfo.value = { ...userStore.user };
@@ -57,6 +59,7 @@ const update = async () => {
       return; // 画像のアップロードに失敗した場合はここで処理を中断
     }
   }
+
   if (Object.keys(updates).length > 0) {
     try {
       const res = await axiosInstance.put('/user/update', updates);

--- a/client/src/views/DiaryView.vue
+++ b/client/src/views/DiaryView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed, watch } from 'vue';
 import { usePostsStore } from '@/stores/posts';
 import axiosInstance from '@/axios';
 import UserIcon from '@/assets/icons/icon_user.png';
+import { signInToFirebase } from '@/firebase';
 
 const postsStore = usePostsStore();
 const diaries = computed(() => postsStore.userPosts);
@@ -17,6 +18,7 @@ const correctionRequest = ref(false);
 const currentIndex = computed(() => diaries.value.findIndex(diary => diary.postId === selectedDiary.value.postId));
 
 onMounted(async () => {
+  await signInToFirebase();
   await postsStore.fetchMyPosts();
 });
 

--- a/client/src/views/EditmeView.vue
+++ b/client/src/views/EditmeView.vue
@@ -5,6 +5,7 @@ import { useUserStore } from '@/stores/user';
 import axiosInstance from '@/axios';
 import PopupForm from '@/components/PopupForm.vue';
 import UserIcon from '@/assets/icons/icon_user.png';
+import { signInToFirebase } from '@/firebase';
 
 const userStore = useUserStore();
 const postsStore = usePostsStore();
@@ -19,6 +20,7 @@ const currentInputText = ref('');
 const selectedPostId = ref(null);
 
 onMounted(async () => {
+  await signInToFirebase();
   // await postsStore.fetchPostsWithDetail();
   await userStore.updateLastVisitedEditMe(); // 最終訪問日を更新
 });

--- a/client/src/views/FeedView.vue
+++ b/client/src/views/FeedView.vue
@@ -5,6 +5,7 @@ import { usePostsStore } from '@/stores/posts';
 import axiosInstance from '@/axios';
 import PopupForm from '@/components/PopupForm.vue';
 import UserIcon from '@/assets/icons/icon_user.png';
+import { signInToFirebase } from '@/firebase';
 
 const postsStore = usePostsStore();
 const posts = computed(() => postsStore.allPosts);
@@ -21,6 +22,7 @@ const selectedPostId = ref(null);
 
 // マウント時にpostsデータを取得
 onMounted(async () => {
+  await signInToFirebase();
   await postsStore.fetchPostsWithDetail();
 });
 

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue';
-import { auth } from '@/firebase';
+import { auth, signInToFirebase } from '@/firebase';
 import { getRedirectResult } from 'firebase/auth';
 import axiosInstance from '@/axios';
 import { useLoginModalStore } from '@/stores/loginModal';
@@ -27,9 +27,12 @@ onMounted(() => {
           });
           console.log('レスポンスjwt', res.data.jwt);
           userStore.user = res.data.user; // ユーザー情報を保存
-          console.log('lastVisitedEditMe:', res.data.user.lastVisitedEditMe);
           userStore.lastVisitedEditMe = res.data.user.lastVisitedEditMe;
           localStorage.setItem('jwt', res.data.jwt); // JWTトークンを保存
+          localStorage.setItem('googleIdToken', googleIdToken); // Cloud Storageへのアクセス用にGoogle IDトークンを保存
+
+          await signInToFirebase();
+
           if (userStore.isLoggedIn) {
             await postsStore.fetchPostsWithDetail(); // ログインが確認できたらポストデータをフェッチ
           }


### PR DESCRIPTION
This pull request to change to ensure Firebase authentication is completed before accessing storage from the client side, based on the updated Cloud Firestore access rules.

Here are the key changes:

**1. Firebase Authentication:**
   - Add Firebase authentication in the client side code.
   - Users are authenticated with Firebase before accessing storage for profile image creation, update, and retrieval.

These changes are necessary to comply with the updated Cloud Firestore access rules.